### PR TITLE
Added missing scripts and changed Readme for mounting a dev volume

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# Docker dev
+dev/
+
 # C extensions
 *.so
 
@@ -65,6 +68,8 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/build/
+docs/source/docstring/
 
 # PyBuilder
 target/

--- a/README.md
+++ b/README.md
@@ -32,16 +32,18 @@ $ sudo systemctl status docker # check that docker is active
 $ docker build -t pyrobolearn .
 ```
 3. Launch
+
+
 You can now start the python interpreter with every library already installed
 
 ```bash
-$ docker run -p 11311:11311 -v catkin_ws:/pyrobolearn/catkin_ws/ -ti pyrobolearn python3
+$ docker run -p 11311:11311 -v $PWD/dev:/pyrobolearn/dev/:rw -ti pyrobolearn python3
 ```
 
 To open an interactive terminal in the docker image use:
 
 ```bash
-$ docker run -p 11311:11311 -v catkin_ws:/pyrobolearn/catkin_ws/ -ti pyrobolearn /bin/bash
+$ docker run -p 11311:11311 -v $PWD/dev:/pyrobolearn/dev/:rw -ti pyrobolearn /bin/bash
 ```
 
 4. nvidia-docker
@@ -58,7 +60,7 @@ sudo pkill -SIGHUP dockerd
 
 And use:
 ```bash
-$ nvidia-docker run -p 11311:11311 -v catkin_ws:/pyrobolearn/catkin_ws/ -ti pyrobolearn
+$ nvidia-docker run -p 11311:11311 -v $PWD/dev:/pyrobolearn/dev/:rw -ti pyrobolearn
 ```
 
 ### Ubuntu


### PR DESCRIPTION
Updated Dockerfile to add the missing scripts and changed the loaded volume.

- Missing scripts processed but I'm not sure the audio scripts were useful
- We can now develop in the $PWD/dev directory, and all the files are automagically copied in the container.
- Now we clone the last version of pyrobolearn directly in the container before installing it as a pip package.

