### PR TITLE
Update index.md

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,6 +1,6 @@
 # PyRoboLearn
 
-Abstract: "On the quest for building autonomous robots, several robot learning frameworks with different functionalities have 
+On the quest for building autonomous robots, several robot learning frameworks with different functionalities have 
 recently been developed. Yet, frameworks that combine diverse learning paradigms (such as imitation and reinforcement learning) 
 into a common place are scarce. Existing ones tend to be robot-specific, and often require time-consuming work to be used with 
 other robots. 
@@ -11,10 +11,10 @@ paradigms into a single framework. Our framework provides a plethora of robotic 
 PyRoboLearn is developed with a particular focus on modularity, flexibility, generality, and simplicity to favor (re)usability. 
 This is achieved by abstracting each key concept, undertaking a modular programming approach, minimizing the coupling among the 
 different modules, and favoring composition over inheritance for better flexibility. We demonstrate the different features and 
-utility of our framework through different use cases."
+utility of our framework through different use cases.
 
-- Link to paper
-- Link to [Github repository](https://github.com/robotlearn/pyrobolearn)
-- Link to [documentation](https://github.com/robotlearn/pyrobolearn/tree/master/docs)
-- Link to [examples](https://github.com/robotlearn/pyrobolearn/tree/master/examples)
-- Link to [videos](https://www.youtube.com/playlist?list=PL7luWwjSAezVxBTindZWUo7hn-Dj9w3gL)
+- Paper
+- [Github repository](https://github.com/robotlearn/pyrobolearn)
+- [Documentation](https://github.com/robotlearn/pyrobolearn/tree/master/docs)
+- [Examples](https://github.com/robotlearn/pyrobolearn/tree/master/examples)
+- [Videos](https://www.youtube.com/playlist?list=PL7luWwjSAezVxBTindZWUo7hn-Dj9w3gL)


### PR DESCRIPTION
@bdelhaisse 
I would also do:
1. Replace "PyRoboLearn's homepage" by "PyRoboLearn"
2. Replace "This is the main page for PyRoboLearn" by "A Python Framework for Robot Learning Practitioners"
3. Can we use the same button we have for "View in github" to replace the list of bullet points for the links we provide. We may have buttons such as "View in ArXiv", "View in YouTube"...Etc.