### PR TITLE
Updated path where BulletClient is.

### DIFF
--- a/pyrobolearn/simulators/bullet.py
+++ b/pyrobolearn/simulators/bullet.py
@@ -32,7 +32,8 @@ import numpy as np
 # import pybullet
 import pybullet
 import pybullet_data
-from pybullet_envs.bullet.bullet_client import BulletClient
+# from pybullet_envs.bullet.bullet_client import BulletClient
+from pybullet_utils.bullet_client import BulletClient
 
 # import PRL simulator
 from pyrobolearn.simulators.simulator import Simulator


### PR DESCRIPTION
BulletClient is not part of ` pybullet_envs` anymore as commented [here](https://www.gitmemory.com/issue/bulletphysics/bullet3/2536/579292047). The import in `bullet.py` is updated accordingly. 