### PR TITLE
Change collections to collections.abc to prevent breaking with Python 3.9

### DIFF
--- a/pyrobolearn/actions/action.py
+++ b/pyrobolearn/actions/action.py
@@ -6,7 +6,7 @@ This file defines the `Action` class, which is returned by the policy and given 
 """
 
 import copy
-import collections
+import collections.abc
 # from abc import ABCMeta, abstractmethod
 import numpy as np
 import torch
@@ -122,7 +122,7 @@ class Action(object):
             raise AttributeError("Trying to add internal actions to the current action while it already has some data. "
                                  "A action should be a combination of actions or should contain some kind of data, "
                                  "but not both.")
-        if isinstance(actions, collections.Iterable):
+        if isinstance(actions, collections.abc.Iterable):
             for action in actions:
                 if not isinstance(action, Action):
                     raise TypeError("One of the given actions is not an instance of Action.")
@@ -152,7 +152,7 @@ class Action(object):
             data: the data to set
         """
         if self.has_actions():  # combined actions
-            if not isinstance(data, collections.Iterable):
+            if not isinstance(data, collections.abc.Iterable):
                 raise TypeError("data is not an iterator")
             if len(self._actions) != len(data):
                 raise ValueError("The number of actions is different from the number of data segments")
@@ -226,7 +226,7 @@ class Action(object):
             data (torch.Tensor, list of torch.Tensors): data to set.
         """
         if self.has_actions():  # combined actions
-            if not isinstance(data, collections.Iterable):
+            if not isinstance(data, collections.abc.Iterable):
                 raise TypeError("data is not an iterator")
             if len(self._actions) != len(data):
                 raise ValueError("The number of actions is different from the number of data segments")
@@ -486,7 +486,7 @@ class Action(object):
                                  "some kind of data, but not both.")
         if isinstance(action, Action):
             self._actions.add(action)
-        elif isinstance(action, collections.Iterable):
+        elif isinstance(action, collections.abc.Iterable):
             for i, s in enumerate(action):
                 if not isinstance(s, Action):
                     raise TypeError("The item {} in the given list is not an instance of Action".format(i))

--- a/pyrobolearn/actions/robot_actions/actuator_actions.py
+++ b/pyrobolearn/actions/robot_actions/actuator_actions.py
@@ -4,7 +4,7 @@
 """
 
 from abc import ABCMeta
-import collections
+import collections.abc
 import numpy as np
 import copy
 

--- a/pyrobolearn/algos/sac.py
+++ b/pyrobolearn/algos/sac.py
@@ -6,7 +6,7 @@ Define the SAC reinforcement learning algorithm. This is a model-free, off-polic
 """
 
 import copy
-import collections
+import collections.abc
 
 from pyrobolearn.algos.rl_algo import GradientRLAlgo, Explorer, Evaluator, Updater
 
@@ -283,7 +283,7 @@ class SAC(GradientRLAlgo):
         """
 
         # check approximators
-        if not isinstance(approximators, collections.Iterable):
+        if not isinstance(approximators, collections.abc.Iterable):
             raise TypeError("Expecting the approximators to be a list containing a Policy, a Value, and at least 2 "
                             "QValues")
         policy, value, q_values = None, None, []

--- a/pyrobolearn/algos/updater.py
+++ b/pyrobolearn/algos/updater.py
@@ -12,7 +12,7 @@ Dependencies:
 - `pyrobolearn/samplers`: to sample from batches
 """
 
-import collections
+import collections.abc
 
 # TODO: makes the 5 following classes inherit from the same Parent class
 from pyrobolearn.approximators import Approximator
@@ -97,7 +97,7 @@ class Updater(object):
     @approximators.setter
     def approximators(self, approximators):
         """Set the approximator instances."""
-        if not isinstance(approximators, collections.Iterable):
+        if not isinstance(approximators, collections.abc.Iterable):
             approximators = [approximators]
         for approximator in approximators:
             if not isinstance(approximator, (Approximator, Policy, Value, ActorCritic, DynamicModel, Exploration)):
@@ -140,7 +140,7 @@ class Updater(object):
     def losses(self, losses):
         """Set the losses."""
         # check that the losses are the correct data type
-        if not isinstance(losses, collections.Iterable):
+        if not isinstance(losses, collections.abc.Iterable):
             losses = [losses]
         for loss in losses:
             if not isinstance(loss, Loss):
@@ -162,7 +162,7 @@ class Updater(object):
     def optimizers(self, optimizers):
         """Set the optimizers."""
         # check that the optimizers are the correct data type
-        if not isinstance(optimizers, collections.Iterable):
+        if not isinstance(optimizers, collections.abc.Iterable):
             optimizers = [optimizers]
         for optimizer in optimizers:
             if not isinstance(optimizer, Optimizer):
@@ -192,7 +192,7 @@ class Updater(object):
         losses and updating the parameters of the approximators."""
         if evaluators is None:
             evaluators = []
-        if not isinstance(evaluators, collections.Iterable):
+        if not isinstance(evaluators, collections.abc.Iterable):
             evaluators = [evaluators]
         for i, evaluator in enumerate(evaluators):
             if not isinstance(evaluator, (Target, Return, Evaluator)):
@@ -210,7 +210,7 @@ class Updater(object):
     def updaters(self, updaters):
         if updaters is None:
             updaters = []
-        if not isinstance(updaters, collections.Iterable):
+        if not isinstance(updaters, collections.abc.Iterable):
             updaters = [updaters]
         for i, updater in enumerate(updaters):
             if not isinstance(updater, ParameterUpdater):

--- a/pyrobolearn/approximators/approximator.py
+++ b/pyrobolearn/approximators/approximator.py
@@ -12,7 +12,7 @@ Dependencies:
 """
 
 import copy
-import collections
+import collections.abc
 import numpy as np
 import torch
 
@@ -171,7 +171,7 @@ class Approximator(object):
             processors = []
         elif callable(processors):
             processors = [processors]
-        elif isinstance(processors, collections.Iterable):
+        elif isinstance(processors, collections.abc.Iterable):
             for idx, processor in enumerate(processors):
                 if not callable(processor):
                     raise ValueError("The {} processor {} is not callable.".format(idx, processor))
@@ -192,7 +192,7 @@ class Approximator(object):
             processors = []
         elif callable(processors):
             processors = [processors]
-        elif isinstance(processors, collections.Iterable):
+        elif isinstance(processors, collections.abc.Iterable):
             for idx, processor in enumerate(processors):
                 if not callable(processor):
                     raise ValueError("The {} processor {} is not callable.".format(idx, processor))

--- a/pyrobolearn/approximators/basic.py
+++ b/pyrobolearn/approximators/basic.py
@@ -10,7 +10,7 @@ Dependencies:
 - `pyrobolearn.actions`
 """
 
-import collections
+import collections.abc
 import numpy as np
 import torch
 

--- a/pyrobolearn/approximators/nn.py
+++ b/pyrobolearn/approximators/nn.py
@@ -8,7 +8,7 @@ Dependencies:
 - `pyrobolearn.actions`
 """
 
-import collections
+import collections.abc
 import numpy as np
 import torch
 

--- a/pyrobolearn/distributions/modules.py
+++ b/pyrobolearn/distributions/modules.py
@@ -15,7 +15,7 @@ References:
 
 from abc import ABCMeta
 
-import collections
+import collections.abc
 import numpy as np
 import torch
 
@@ -981,7 +981,7 @@ class GaussianMixtureModule(torch.nn.Module):
     @means.setter
     def means(self, means):
         """Set the mean modules."""
-        if not isinstance(means, collections.Iterable):
+        if not isinstance(means, collections.abc.Iterable):
             means = [means]
         for mean in means:
             if not isinstance(mean, torch.nn.Module):
@@ -997,7 +997,7 @@ class GaussianMixtureModule(torch.nn.Module):
     @covariances.setter
     def covariances(self, covariances):
         """Set the covariance modules."""
-        if not isinstance(covariances, collections.Iterable):
+        if not isinstance(covariances, collections.abc.Iterable):
             covariances = [covariances]
         for covariance in covariances:
             if not isinstance(covariance, torch.nn.Module):

--- a/pyrobolearn/dynamics/dynamic.py
+++ b/pyrobolearn/dynamics/dynamic.py
@@ -12,7 +12,7 @@ Dependencies:
 """
 
 import copy
-import collections
+import collections.abc
 from abc import ABCMeta, abstractmethod
 import numpy as np
 import torch
@@ -99,13 +99,13 @@ class DynamicModel(object):
         # preprocessors and postprocessors
         if preprocessors is None:
             preprocessors = []
-        if not isinstance(preprocessors, collections.Iterable):
+        if not isinstance(preprocessors, collections.abc.Iterable):
             preprocessors = [preprocessors]
         self.preprocessors = preprocessors
 
         if postprocessors is None:
             postprocessors = []
-        if not isinstance(postprocessors, collections.Iterable):
+        if not isinstance(postprocessors, collections.abc.Iterable):
             postprocessors = [postprocessors]
         self.postprocessors = postprocessors
 

--- a/pyrobolearn/exploration/actions/action_exploration.py
+++ b/pyrobolearn/exploration/actions/action_exploration.py
@@ -18,7 +18,7 @@ References:
     [1] "Reinforcement Learning: An Introduction", Sutton and Barto, 2018
 """
 
-import collections
+import collections.abc
 import torch
 
 from pyrobolearn.actions import Action
@@ -97,7 +97,7 @@ class ActionExploration(Exploration):
                 raise ValueError("Expecting to be given an action or a list of explorations, not both.")
 
             # transform the explorations to a list if not iterable
-            if not isinstance(explorations, collections.Iterable):
+            if not isinstance(explorations, collections.abc.Iterable):
                 explorations = [explorations]
 
             # check the length of exploration strategies and the number of actions in the policy

--- a/pyrobolearn/losses/loss.py
+++ b/pyrobolearn/losses/loss.py
@@ -11,7 +11,7 @@ optimize them, while rewards / costs depends on the state(s) and action(s) and a
 from abc import ABCMeta
 import operator
 import copy
-import collections
+import collections.abc
 
 import torch
 
@@ -55,7 +55,7 @@ class Loss(object):
         """Set the inner losses."""
         if losses is None:
             losses = []
-        elif isinstance(losses, collections.Iterable):
+        elif isinstance(losses, collections.abc.Iterable):
             for loss in losses:
                 if not isinstance(loss, Loss):
                     raise TypeError("Expecting a Loss instance for each item in the iterator.")

--- a/pyrobolearn/metrics/metric.py
+++ b/pyrobolearn/metrics/metric.py
@@ -3,7 +3,7 @@
 """Defines the various metrics used in different learning paradigms.
 """
 
-import collections
+import collections.abc
 import numpy as np
 import matplotlib.pyplot as plt
 
@@ -51,7 +51,7 @@ class Metric(object):
         """Set the inner list of metrics."""
         if metrics is None:
             metrics = []
-        if not isinstance(metrics, collections.Iterable):
+        if not isinstance(metrics, collections.abc.Iterable):
             metrics = [metrics]
         self._check_recursively_metric_type(metrics)
         self._metrics = metrics
@@ -69,7 +69,7 @@ class Metric(object):
 
     def _check_recursively_metric_type(self, metrics):
         """Check recursively the metric types."""
-        if isinstance(metrics, collections.Iterable):
+        if isinstance(metrics, collections.abc.Iterable):
             for metric in metrics:
                 self._check_recursively_metric_type(metric)
         elif not isinstance(metrics, Metric):

--- a/pyrobolearn/models/basics/linear.py
+++ b/pyrobolearn/models/basics/linear.py
@@ -7,7 +7,7 @@ The linear model is a discriminative deterministic model given by: :math:`y = f(
 
 import copy
 import types
-import collections
+import collections.abc
 
 try:
     import cPickle as pickle
@@ -171,7 +171,7 @@ class Linear(object):
             self.model.load_state_dict(parameters.model.state_dict())
         elif isinstance(parameters, torch.nn.Module):
             self.model.load_state_dict(parameters.state_dict())
-        elif isinstance(parameters, (types.GeneratorType, collections.Iterable)):
+        elif isinstance(parameters, (types.GeneratorType, collections.abc.Iterable)):
             for model_params, other_params in zip(self.parameters(), parameters):
                 model_params.data.copy_(other_params.data)
         else:

--- a/pyrobolearn/models/basics/polynomial.py
+++ b/pyrobolearn/models/basics/polynomial.py
@@ -8,7 +8,7 @@ The polynomial model is a discriminative deterministic model given by: :math:`y 
 
 import copy
 # import inspect
-import collections
+import collections.abc
 import numpy as np
 import torch
 
@@ -55,7 +55,7 @@ class PolynomialFunction(object):
         # checks
         if isinstance(degree, int):
             degree = range(degree + 1)
-        elif isinstance(degree, collections.Iterable):
+        elif isinstance(degree, collections.abc.Iterable):
             for d in degree:
                 if not isinstance(d, int):
                     raise TypeError("Expecting the given degrees to be positive integers, but got {}".format(type(d)))

--- a/pyrobolearn/models/model.py
+++ b/pyrobolearn/models/model.py
@@ -235,7 +235,7 @@ class Model(object):
         #     self.model.load_state_dict(parameters.model.state_dict())
         # elif isinstance(parameters, torch.nn.Module):
         #     self.model.load_state_dict(parameters.state_dict())
-        # elif isinstance(parameters, (types.GeneratorType, collections.Iterable)):
+        # elif isinstance(parameters, (types.GeneratorType, collections.abc.Iterable)):
         #     for model_params, other_params in zip(self.parameters(), parameters):
         #         model_params.data.copy_(other_params.data)
         # else:

--- a/pyrobolearn/models/nn/dnn.py
+++ b/pyrobolearn/models/nn/dnn.py
@@ -20,7 +20,7 @@ References:
 
 import copy
 import types
-import collections
+import collections.abc
 import numpy as np
 import torch
 
@@ -237,7 +237,7 @@ class NN(object):  # Model
             self.model.load_state_dict(parameters.model.state_dict())
         elif isinstance(parameters, torch.nn.Module):
             self.model.load_state_dict(parameters.state_dict())
-        elif isinstance(parameters, (types.GeneratorType, collections.Iterable)):
+        elif isinstance(parameters, (types.GeneratorType, collections.abc.Iterable)):
             for model_params, other_params in zip(self.parameters(), parameters):
                 model_params.data.copy_(other_params.data)
         else:

--- a/pyrobolearn/physics/actuators_randomizer.py
+++ b/pyrobolearn/physics/actuators_randomizer.py
@@ -6,7 +6,7 @@ Dependencies:
 - `pyrobolearn.physics`
 """
 
-import collections
+import collections.abc
 import numpy as np
 
 from pyrobolearn.physics.robot_physics_randomizer import RobotPhysicsRandomizer

--- a/pyrobolearn/physics/joint_physics_randomizer.py
+++ b/pyrobolearn/physics/joint_physics_randomizer.py
@@ -7,7 +7,7 @@ Dependencies:
 - `pyrobolearn.physics`
 """
 
-import collections
+import collections.abc
 import numpy as np
 
 from pyrobolearn.physics.body_physics_randomizer import BodyPhysicsRandomizer
@@ -71,7 +71,7 @@ class JointPhysicsRandomizer(BodyPhysicsRandomizer):
             joints = self.body.joints
         elif isinstance(joints, int):
             joints = [joints]
-        elif isinstance(joints, collections.Iterable):
+        elif isinstance(joints, collections.abc.Iterable):
             for idx, joint in enumerate(joints):
                 if not isinstance(joint, int):
                     raise TypeError("The {} element of the given list of joints is not an integer, instead got: "

--- a/pyrobolearn/physics/link_physics_randomizer.py
+++ b/pyrobolearn/physics/link_physics_randomizer.py
@@ -7,7 +7,7 @@ Dependencies:
 - `pyrobolearn.physics`
 """
 
-import collections
+import collections.abc
 import numpy as np
 
 from pyrobolearn.physics.body_physics_randomizer import BodyPhysicsRandomizer
@@ -99,7 +99,7 @@ class LinkPhysicsRandomizer(BodyPhysicsRandomizer):
             links = list(range(self.body.num_links))
         elif isinstance(links, int):
             links = [links]
-        elif isinstance(links, collections.Iterable):
+        elif isinstance(links, collections.abc.Iterable):
             for idx, link in enumerate(links):
                 if not isinstance(link, int):
                     raise TypeError("The {} element of the given list of links is not an integer, instead got: "

--- a/pyrobolearn/physics/robot_physics_randomizer.py
+++ b/pyrobolearn/physics/robot_physics_randomizer.py
@@ -6,7 +6,7 @@ Dependencies:
 - `pyrobolearn.physics`
 """
 
-import collections
+import collections.abc
 
 from pyrobolearn.physics.body_physics_randomizer import BodyPhysicsRandomizer
 from pyrobolearn.physics.link_physics_randomizer import LinkPhysicsRandomizer
@@ -63,7 +63,7 @@ class RobotPhysicsRandomizer(BodyPhysicsRandomizer):
             links = [LinkPhysicsRandomizer(self.body, links)]
         elif isinstance(links, LinkPhysicsRandomizer):
             links = [links]
-        elif isinstance(links, collections.Iterable):
+        elif isinstance(links, collections.abc.Iterable):
             link_list = []
             for idx, link in enumerate(links):
                 if isinstance(link, int):
@@ -90,7 +90,7 @@ class RobotPhysicsRandomizer(BodyPhysicsRandomizer):
             joints = [JointPhysicsRandomizer(self.body, joints)]
         elif isinstance(joints, JointPhysicsRandomizer):
             joints = [joints]
-        elif isinstance(joints, collections.Iterable):
+        elif isinstance(joints, collections.abc.Iterable):
             joint_list = []
             for idx, joint in enumerate(joints):
                 if isinstance(joint, int):

--- a/pyrobolearn/physics/sensors_randomizer.py
+++ b/pyrobolearn/physics/sensors_randomizer.py
@@ -6,7 +6,7 @@ Dependencies:
 - `pyrobolearn.physics`
 """
 
-import collections
+import collections.abc
 import numpy as np
 
 from pyrobolearn.physics.robot_physics_randomizer import RobotPhysicsRandomizer

--- a/pyrobolearn/policies/policy.py
+++ b/pyrobolearn/policies/policy.py
@@ -15,7 +15,7 @@ Dependencies:
 
 import copy
 import pickle
-import collections
+import collections.abc
 import numpy as np
 import torch
 
@@ -152,13 +152,13 @@ class Policy(object):
         # preprocessors and postprocessors
         if preprocessors is None:
             preprocessors = []
-        if not isinstance(preprocessors, collections.Iterable):
+        if not isinstance(preprocessors, collections.abc.Iterable):
             preprocessors = [preprocessors]
         self.preprocessors = preprocessors
 
         if postprocessors is None:
             postprocessors = []
-        if not isinstance(postprocessors, collections.Iterable):
+        if not isinstance(postprocessors, collections.abc.Iterable):
             postprocessors = [postprocessors]
         self.postprocessors = postprocessors
 

--- a/pyrobolearn/returns/targets.py
+++ b/pyrobolearn/returns/targets.py
@@ -10,7 +10,7 @@ Dependencies:
 """
 
 from abc import ABCMeta
-import collections
+import collections.abc
 
 import torch
 
@@ -45,7 +45,7 @@ class Target(object):
         """
         # check targets
         if targets is not None:
-            if not isinstance(targets, collections.Iterable):
+            if not isinstance(targets, collections.abc.Iterable):
                 targets = [targets]
             for i, target in enumerate(targets):
                 if not isinstance(target, Target):
@@ -272,7 +272,7 @@ class ValueTarget(GammaTarget):
             gamma (float): discount factor
         """
         super(ValueTarget, self).__init__(gamma)
-        if not isinstance(values, collections.Iterable):
+        if not isinstance(values, collections.abc.Iterable):
             values = [values]
         for i, value in enumerate(values):
             if not isinstance(value, Value):
@@ -312,7 +312,7 @@ class QValueTarget(GammaTarget):
         super(QValueTarget, self).__init__(gamma)
 
         # check Q-values
-        if not isinstance(q_values, collections.Iterable):
+        if not isinstance(q_values, collections.abc.Iterable):
             q_values = [q_values]
         for i, value in enumerate(q_values):
             if not isinstance(value, QValue):
@@ -357,7 +357,7 @@ class QLearningTarget(GammaTarget):
             gamma (float): discount factor
         """
         super(QLearningTarget, self).__init__(gamma)
-        if not isinstance(q_values, collections.Iterable):
+        if not isinstance(q_values, collections.abc.Iterable):
             q_values = [q_values]
         for i, value in enumerate(q_values):
             if not isinstance(value, QValue):
@@ -402,7 +402,7 @@ class EntropyValueTarget(Target):
         super(EntropyValueTarget, self).__init__()
 
         # check Q-values
-        if not isinstance(q_values, collections.Iterable):
+        if not isinstance(q_values, collections.abc.Iterable):
             q_values = [q_values]
         for i, value in enumerate(q_values):
             if not isinstance(value, QValue):

--- a/pyrobolearn/rewards/reward.py
+++ b/pyrobolearn/rewards/reward.py
@@ -18,7 +18,7 @@ Dependencies:
 
 import sys
 import numpy as np
-import collections
+import collections.abc
 import operator
 import copy
 
@@ -217,7 +217,7 @@ class Reward(object):
         """Set the inner rewards."""
         if rewards is None:
             rewards = []
-        elif isinstance(rewards, collections.Iterable):
+        elif isinstance(rewards, collections.abc.Iterable):
             for reward in rewards:
                 if not isinstance(reward, Reward):
                     raise TypeError("Expecting a Reward instance for each item in the iterator.")

--- a/pyrobolearn/robots/legged_robot.py
+++ b/pyrobolearn/robots/legged_robot.py
@@ -6,7 +6,7 @@ Classes that are defined here: LeggedRobot, BipedRobot, QuadrupedRobot, HexapodR
 """
 
 import os
-import collections
+import collections.abc
 import numpy as np
 from scipy.spatial import ConvexHull
 
@@ -150,7 +150,7 @@ class LeggedRobot(Robot):
         for foot_id, frict in zip(feet_ids, frictions):
             if isinstance(foot_id, int):
                 self.sim.change_dynamics(self.id, foot_id, lateral_friction=frict)
-            elif isinstance(foot_id, collections.Iterable):
+            elif isinstance(foot_id, collections.abc.Iterable):
                 for idx in foot_id:
                     self.sim.change_dynamics(self.id, idx, lateral_friction=frict)
             else:

--- a/pyrobolearn/robots/minitaur.py
+++ b/pyrobolearn/robots/minitaur.py
@@ -4,7 +4,7 @@
 """
 
 import os
-import collections
+import collections.abc
 import numpy as np
 
 from pyrobolearn.robots.legged_robot import QuadrupedRobot
@@ -205,14 +205,14 @@ class Minitaur(QuadrupedRobot):
                     raise ValueError("Expecting the jointId to be an outer joint as the legs of the minitaur are "
                                      "coupled")
                 joint_ids = [joint_ids, joint_ids + 3]
-                if isinstance(positions, collections.Iterable):
+                if isinstance(positions, collections.abc.Iterable):
                     positions = positions[0]
 
                 positions = np.array([positions, -positions])
                 positions += self.init_joint_positions[self.get_q_indices(joint_ids)]
 
             # if multiple joint ids
-            elif isinstance(joint_ids, collections.Iterable):
+            elif isinstance(joint_ids, collections.abc.Iterable):
                 # for each outer joint id, get the corresponding inner joint id
                 joints = []
                 for joint in joint_ids:

--- a/pyrobolearn/robots/robot.py
+++ b/pyrobolearn/robots/robot.py
@@ -14,7 +14,7 @@ Dependencies:
 import os
 import time
 import copy
-import collections
+import collections.abc
 import xml.etree.ElementTree as ET
 # import rbdl
 import numpy as np
@@ -706,7 +706,7 @@ class Robot(ControllableBody):
                 raise TypeError("Incorrect type")
 
         # list of joints
-        if isinstance(joint, collections.Iterable) and not isinstance(joint, str):
+        if isinstance(joint, collections.abc.Iterable) and not isinstance(joint, str):
             return [get_index(joint) for joint in joint]
 
         # one joint
@@ -1333,7 +1333,7 @@ class Robot(ControllableBody):
         else:
             if joint_ids is None:
                 joint_ids = self.joints
-            if not isinstance(joint_ids, collections.Iterable):
+            if not isinstance(joint_ids, collections.abc.Iterable):
                 raise TypeError("Expecting jointId to be a tuple, list, or numpy array, got instead "
                                 "{}".format(type(joint_ids)))
             if torques is None:
@@ -1579,7 +1579,7 @@ class Robot(ControllableBody):
                 raise TypeError("Incorrect type")
 
         # list of links
-        if isinstance(link, collections.Iterable) and not isinstance(link, str):
+        if isinstance(link, collections.abc.Iterable) and not isinstance(link, str):
             return [get_index(link) for link in link]
 
         # one link
@@ -1619,7 +1619,7 @@ class Robot(ControllableBody):
             list[int], list[list[int]]: chain(s) containing the link ids.
         """
         if from_link_id is None:
-            if isinstance(to_link_id, collections.Iterable):
+            if isinstance(to_link_id, collections.abc.Iterable):
                 from_link_id = [-1] * len(to_link_id)
             else:
                 from_link_id = -1
@@ -2669,7 +2669,7 @@ class Robot(ControllableBody):
                 raise TypeError("Incorrect type")
 
         # list of links
-        if isinstance(end_effector, collections.Iterable) and not isinstance(end_effector, str):
+        if isinstance(end_effector, collections.abc.Iterable) and not isinstance(end_effector, str):
             return [get_index(link) for link in end_effector]
 
         # one link
@@ -4700,7 +4700,7 @@ class Robot(ControllableBody):
                 joint_ids = [joint_ids]
             elif isinstance(joint_ids, str):  # joint name
                 joint_ids = [self.get_joint_ids(joint_ids)]
-            elif isinstance(joint_ids, collections.Iterable):
+            elif isinstance(joint_ids, collections.abc.Iterable):
                 joint_ids = [getIndex(jnt) for jnt in joint_ids]
             else:
                 raise TypeError("jointId has to be a None, int, str, or a list/tuple of int/str.")
@@ -4760,7 +4760,7 @@ class Robot(ControllableBody):
                 joint_ids = [joint_ids]
             elif isinstance(joint_ids, str):  # joint name
                 joint_ids = [self.get_joint_ids(joint_ids)]
-            elif isinstance(joint_ids, collections.Iterable):
+            elif isinstance(joint_ids, collections.abc.Iterable):
                 joint_ids = [get_index(joint) for joint in joint_ids]
             else:
                 raise TypeError("jointId has to be a None, int, str, or a list/tuple of int/str.")
@@ -5057,7 +5057,7 @@ class Robot(ControllableBody):
             joint_ids = self.joints
         elif isinstance(joint_ids, int):
             joint_ids = [joint_ids]
-        elif not isinstance(joint_ids, collections.Iterable):
+        elif not isinstance(joint_ids, collections.abc.Iterable):
             raise TypeError("Expecting the given 'joint_ids' to be None, an int, or a list of int, instead got: "
                             "{}".format(joint_ids))
 
@@ -5083,7 +5083,7 @@ class Robot(ControllableBody):
             joint_ids = self.joints
         elif isinstance(joint_ids, int):
             joint_ids = [joint_ids]
-        elif not isinstance(joint_ids, collections.Iterable):
+        elif not isinstance(joint_ids, collections.abc.Iterable):
             raise TypeError("Expecting the given 'joint_ids' to be None, an int, or a list of int, instead got: "
                             "{}".format(joint_ids))
 

--- a/pyrobolearn/simulators/chrono.py
+++ b/pyrobolearn/simulators/chrono.py
@@ -13,7 +13,7 @@ References:
 import os
 import time
 import numpy as np
-from collections import OrderedDict
+from collections.abc import OrderedDict
 
 # import pychrono
 try:

--- a/pyrobolearn/simulators/dart.py
+++ b/pyrobolearn/simulators/dart.py
@@ -47,7 +47,7 @@ References:
 import os
 import time
 import numpy as np
-from collections import OrderedDict
+from collections.abc import OrderedDict
 
 # import dartpy
 try:

--- a/pyrobolearn/simulators/isaac.py
+++ b/pyrobolearn/simulators/isaac.py
@@ -26,7 +26,7 @@ References:
 import os
 import time
 import numpy as np
-from collections import OrderedDict
+from collections.abc import OrderedDict
 
 try:
     import isaacgym

--- a/pyrobolearn/simulators/middlewares/ros_publisher.py
+++ b/pyrobolearn/simulators/middlewares/ros_publisher.py
@@ -3,7 +3,7 @@
 """Define the abstract robot publisher.
 """
 
-import collections
+import collections.abc
 
 import rospy
 
@@ -60,7 +60,7 @@ class PublisherData(object):
             self.is_group = False
             self.publisher = rospy.Publisher(topic, msg_class, queue_size=queue_size)
             self.msg = msg_class()
-        elif isinstance(topic, collections.Iterable):
+        elif isinstance(topic, collections.abc.Iterable):
             self.is_group = True
             self.publisher = [rospy.Publisher(t, msg_class, queue_size=queue_size) for t in topic]
             self.msg = [msg_class() for _ in topic]
@@ -86,7 +86,7 @@ class PublisherData(object):
                 data = data[indices]
 
         # if multiple publisher
-        if isinstance(self.publisher, collections.Iterable):
+        if isinstance(self.publisher, collections.abc.Iterable):
             if indices is None:  # publish to every topics the corresponding data
                 for idx, (pub, msg) in enumerate(zip(self.publisher, data)):
                     pub.publish(msg)
@@ -131,7 +131,7 @@ class PublisherData(object):
         # TODO: use `rsetattr` (which is implemented in pyrobolearn/utils/__init__.py)
         if self.is_group:
             if indices is None:  # set every message attribute
-                if isinstance(values, collections.Iterable):
+                if isinstance(values, collections.abc.Iterable):
                     for msg, value in zip(self.msg, values):
                         setattr(msg, key, value)
                 else:
@@ -141,7 +141,7 @@ class PublisherData(object):
                 if isinstance(indices, int):
                     setattr(self.msg[indices], key, values)
                 else:
-                    if isinstance(values, collections.Iterable):
+                    if isinstance(values, collections.abc.Iterable):
                         for i, index in enumerate(indices):
                             setattr(self.msg[index], key, values[i])
                     else:
@@ -169,7 +169,7 @@ class PublisherData(object):
                 return [getattr(msg, key) for msg in self.msg]
             elif isinstance(indices, int):
                 return getattr(self.msg[indices], key)
-            elif isinstance(indices, collections.Iterable):
+            elif isinstance(indices, collections.abc.Iterable):
                 return [getattr(self.msg[index], key) for index in indices]
             else:
                 raise TypeError("Expecting the given indices to be an int, None, or list of int, but got instead: "
@@ -181,7 +181,7 @@ class PublisherData(object):
         Unsubscribe from a topic. Topic instance is no longer valid after this call. Additional calls to `unregister()`
         have no effect.
         """
-        if isinstance(self.publisher, collections.Iterable):
+        if isinstance(self.publisher, collections.abc.Iterable):
             for publisher in self.publisher:
                 publisher.unregister()
         else:
@@ -250,7 +250,7 @@ class Publisher(object):
         # create new publisher
         publisher = PublisherData(topic=topic, msg_class=msg_class, queue_size=queue_size)
         self.publishers[name] = publisher
-        if isinstance(topic, collections.Iterable):
+        if isinstance(topic, collections.abc.Iterable):
             for t in topic:
                 self.topics_to_publisher_name[t] = name
         else:

--- a/pyrobolearn/simulators/middlewares/ros_service.py
+++ b/pyrobolearn/simulators/middlewares/ros_service.py
@@ -3,7 +3,7 @@
 """Define the abstract ROS service.
 """
 
-import collections
+import collections.abc
 import rospy
 
 
@@ -33,12 +33,12 @@ class ROSService(object):
         """
         if isinstance(name, str):
             name = [name]
-        elif not isinstance(name, collections.Iterable):
+        elif not isinstance(name, collections.abc.Iterable):
             raise TypeError("Expecting the given 'name' to be a string, list of string, but got instead: "
                             "{}".format(type(name)))
         self.names = name
 
-        if not isinstance(service_class, collections.Iterable):
+        if not isinstance(service_class, collections.abc.Iterable):
             service_class = [service_class]
         self.service_classes = service_class
 
@@ -77,10 +77,10 @@ class ROSService(object):
         """
         if isinstance(names, str):
             names = [names]
-        elif not isinstance(names, collections.Iterable):
+        elif not isinstance(names, collections.abc.Iterable):
             raise TypeError("Expecting the given 'names' to be a string, list of string, but got instead: "
                             "{}".format(type(names)))
-        if not isinstance(service_classes, collections.Iterable):
+        if not isinstance(service_classes, collections.abc.Iterable):
             service_classes = [service_classes]
 
         for name, service_class in zip(names, service_classes):

--- a/pyrobolearn/simulators/middlewares/ros_subscriber.py
+++ b/pyrobolearn/simulators/middlewares/ros_subscriber.py
@@ -3,7 +3,7 @@
 """Define the abstract robot subscriber.
 """
 
-import collections
+import collections.abc
 
 import numpy as np
 import rospy
@@ -52,7 +52,7 @@ class SubscriberData(object):
             self.is_group = False
             self.subscriber = rospy.Subscriber(topic, msg_class, callback=self.callback)
             self.msg = msg_class()
-        elif isinstance(topic, collections.Iterable):
+        elif isinstance(topic, collections.abc.Iterable):
             self.is_group = True
             self.subscriber = [rospy.Subscriber(t, msg_class, callback=self.callback, callback_args=idx)
                                for idx, t in enumerate(topic)]
@@ -95,7 +95,7 @@ class SubscriberData(object):
                 return [getattr(msg, key) for msg in self.msg]
             elif isinstance(indices, int):
                 return getattr(self.msg[indices], key)
-            elif isinstance(indices, collections.Iterable):
+            elif isinstance(indices, collections.abc.Iterable):
                 return [getattr(self.msg[index], key) for index in indices]
             else:
                 raise TypeError("Expecting the given indices to be an int, None, or list of int, but got instead: "
@@ -107,7 +107,7 @@ class SubscriberData(object):
         Unsubscribe from a topic. Topic instance is no longer valid after this call. Additional calls to `unregister()`
         have no effect.
         """
-        if isinstance(self.subscriber, collections.Iterable):
+        if isinstance(self.subscriber, collections.abc.Iterable):
             for subscriber in self.subscriber:
                 subscriber.unregister()
         else:
@@ -170,7 +170,7 @@ class Subscriber(object):
         # create new subscriber
         subscriber = SubscriberData(topic, msg_class)
         self.subscribers[name] = subscriber
-        if isinstance(topic, collections.Iterable):
+        if isinstance(topic, collections.abc.Iterable):
             for t in topic:
                 self.topics_to_subscriber_name[t] = name
         else:

--- a/pyrobolearn/simulators/mujoco.py
+++ b/pyrobolearn/simulators/mujoco.py
@@ -39,7 +39,7 @@ import os
 import time
 import numpy as np
 import pickle
-from collections import OrderedDict
+from collections.abc import OrderedDict
 
 # import XML parsers to parse / create XML for MuJoCo
 import xml.etree.ElementTree as ET  # XML parser

--- a/pyrobolearn/simulators/raisim.py
+++ b/pyrobolearn/simulators/raisim.py
@@ -35,7 +35,7 @@ References:
 
 import os
 import time
-from collections import OrderedDict
+from collections.abc import OrderedDict
 import numpy as np
 
 

--- a/pyrobolearn/simulators/rbdl_.py
+++ b/pyrobolearn/simulators/rbdl_.py
@@ -13,7 +13,7 @@ References:
     - [2] PEP8: https://www.python.org/dev/peps/pep-0008/
 """
 
-import collections
+import collections.abc
 import rbdl
 
 
@@ -98,7 +98,7 @@ class RBDL(object):
 
     def get_link_names(self, link_ids):
         """Return the link names."""
-        if isinstance(link_ids, collections.Iterable):
+        if isinstance(link_ids, collections.abc.Iterable):
             return [self.model.GetBodyName(link_id) for link_id in link_ids]
         return self.model.GetBodyName(link_ids)
 

--- a/pyrobolearn/states/robot_states/sensor_states.py
+++ b/pyrobolearn/states/robot_states/sensor_states.py
@@ -7,7 +7,7 @@ This includes notably the camera, contact, IMU, force/torque sensors and others.
 
 import copy
 from abc import ABCMeta
-import collections
+import collections.abc
 import numpy as np
 
 # from pyrobolearn.states.robot_states.robot_states import RobotState
@@ -174,7 +174,7 @@ class ContactState(SensorState):
                 state is not a combination of states, but is given some :attr:`data`.
             ticks (int): number of ticks to sleep before getting the next state data.
         """
-        if not isinstance(contacts, collections.Iterable):
+        if not isinstance(contacts, collections.abc.Iterable):
             contacts = [contacts]
         for contact in contacts:
             if not isinstance(contact, ContactSensor):
@@ -230,7 +230,7 @@ class FeetContactState(ContactState):
             for foot in feet:
                 if isinstance(foot, int):
                     feet_ids.append(foot)
-                elif isinstance(foot, collections.Iterable):
+                elif isinstance(foot, collections.abc.Iterable):
                     for f in foot:
                         feet_ids.append(f)
                 else:

--- a/pyrobolearn/states/state.py
+++ b/pyrobolearn/states/state.py
@@ -7,7 +7,7 @@ models such as policies/controllers, dynamic transition functions, value approxi
 """
 
 import copy
-import collections
+import collections.abc
 # from abc import ABCMeta, abstractmethod
 import numpy as np
 import torch
@@ -165,7 +165,7 @@ class State(object):
             raise AttributeError("Trying to add internal states to the current state while it already has some data. "
                                  "A state should be a combination of states or should contain some kind of data, "
                                  "but not both.")
-        if isinstance(states, collections.Iterable):
+        if isinstance(states, collections.abc.Iterable):
             for state in states:
                 if not isinstance(state, State):
                     raise TypeError("One of the given states is not an instance of State.")
@@ -206,7 +206,7 @@ class State(object):
             data: the data to set
         """
         if self.has_states():  # combined states
-            if not isinstance(data, collections.Iterable):
+            if not isinstance(data, collections.abc.Iterable):
                 raise TypeError("data is not an iterator")
             if len(self._states) != len(data):
                 raise ValueError("The number of states is different from the number of data segments")
@@ -298,7 +298,7 @@ class State(object):
             data (torch.Tensor, list of torch.Tensors): data to set.
         """
         if self.has_states():  # combined states
-            if not isinstance(data, collections.Iterable):
+            if not isinstance(data, collections.abc.Iterable):
                 raise TypeError("data is not an iterator")
             if len(self._states) != len(data):
                 raise ValueError("The number of states is different from the number of data segments")
@@ -649,7 +649,7 @@ class State(object):
                                  "some kind of data, but not both.")
         if isinstance(state, State):
             self._states.add(state)
-        elif isinstance(state, collections.Iterable):
+        elif isinstance(state, collections.abc.Iterable):
             for i, s in enumerate(state):
                 if not isinstance(s, State):
                     raise TypeError("The item {} in the given list is not an instance of State".format(i))

--- a/pyrobolearn/storages/storage.py
+++ b/pyrobolearn/storages/storage.py
@@ -10,7 +10,7 @@ See Also:
     - `pyrobolearn.samplers`: this defines how to samples from the storages.
 """
 
-import collections
+import collections.abc
 import copy
 import pickle
 import queue
@@ -153,7 +153,7 @@ class PyTorchStorage(Storage):
                 item.remove(value)
                 value = self._to(value, device=device, dtype=dtype)
                 item.add(value)
-        elif isinstance(item, collections.Iterable):
+        elif isinstance(item, collections.abc.Iterable):
             item = [self._to(value, device=device, dtype=dtype) for value in item]
             # for idx, value in enumerate(item):
             #     item[idx] = self._to(value, device=device, dtype=dtype)
@@ -188,7 +188,7 @@ class PyTorchStorage(Storage):
                 if isinstance(items, dict):
                     for item in items.values():
                         check(item)
-                elif isinstance(items, collections.Iterable):
+                elif isinstance(items, collections.abc.Iterable):
                     for item in items:
                         check(item)
             check(self)
@@ -260,7 +260,7 @@ class ListStorage(list, PyTorchStorage):
 
     def extend(self, iterable):
         """Extend list by appending elements from the iterable."""
-        if not isinstance(iterable, collections.Iterable):
+        if not isinstance(iterable, collections.abc.Iterable):
             raise TypeError("Expecting an iterable.")
         iterable = self._to(iterable, device=self.device, dtype=self.dtype)
         super(ListStorage, self).append(iterable)

--- a/pyrobolearn/tasks/curriculum.py
+++ b/pyrobolearn/tasks/curriculum.py
@@ -17,7 +17,7 @@ References:
     [1] "Curriculum learning", Bengio et al., 2009
 """
 
-import collections
+import collections.abc
 
 from pyrobolearn.worlds import World
 from pyrobolearn.tasks.task import Task, Env
@@ -71,7 +71,7 @@ class CLTask(Task):
         # TODO use an ordered dictionary
         if isinstance(environments, Env):
             environments = [environments]
-        elif isinstance(environments, collections.Iterable):
+        elif isinstance(environments, collections.abc.Iterable):
             if len(environments) < 1:
                 raise ValueError("Expecting the list of environments to at least a length of one.")
             for i, env in enumerate(environments):

--- a/pyrobolearn/tasks/distillation.py
+++ b/pyrobolearn/tasks/distillation.py
@@ -10,7 +10,7 @@ References:
     [1] "Distilling the Knowledge in a Neural Network", Hinton et al., 2015
 """
 
-import collections
+import collections.abc
 import torch
 
 from pyrobolearn.models.model import Model

--- a/pyrobolearn/tasks/imitation.py
+++ b/pyrobolearn/tasks/imitation.py
@@ -7,7 +7,7 @@ Dependencies:
 - `pyrobolearn.tools` (interfaces / bridges to be used to demonstrate a certain skill).
 """
 
-import collections
+import collections.abc
 from itertools import count
 import time
 import numpy as np
@@ -127,9 +127,9 @@ class ILTask(Task):
         """Set the recorders."""
         if recorders is None:
             recorders = [StateRecorder(self.policies.states), ActionRecorder(self.policies.actions)]
-        elif isinstance(recorders, Recorder):  # or not isinstance(recorders, collections.Iterable):
+        elif isinstance(recorders, Recorder):  # or not isinstance(recorders, collections.abc.Iterable):
             recorders = [recorders]
-        if not isinstance(recorders, collections.Iterable):
+        if not isinstance(recorders, collections.abc.Iterable):
             raise TypeError("Expecting a list of recorders.")
         # check each recorder
         for recorder in recorders:

--- a/pyrobolearn/tasks/task.py
+++ b/pyrobolearn/tasks/task.py
@@ -19,7 +19,7 @@ Dependencies:
 - `pyrobolearn.policies`
 """
 
-import collections
+import collections.abc
 import copy
 import pickle
 import time
@@ -79,7 +79,7 @@ class Task(object):
         self.env = environment
 
         # check the policies
-        if isinstance(policies, collections.Iterable):
+        if isinstance(policies, collections.abc.Iterable):
             for policy in policies:
                 if not isinstance(policy, Policy):
                     raise TypeError("Expecting 'policies' to be a list/tuple of Policy instances")

--- a/pyrobolearn/utils/converter.py
+++ b/pyrobolearn/utils/converter.py
@@ -7,7 +7,7 @@ from abc import ABCMeta, abstractmethod
 import numpy as np
 import torch
 import quaternion
-import collections
+import collections.abc
 
 __copyright__ = "Copyright 2018, PyRoboLearn"
 __credits__ = ["Brian Delhaisse"]
@@ -54,7 +54,7 @@ class TypeConverter(object):
     @from_type.setter
     def from_type(self, from_type):
         if from_type is not None:
-            if isinstance(from_type, collections.Iterable):
+            if isinstance(from_type, collections.abc.Iterable):
                 for t in from_type:
                     if not isinstance(t, type):
                         raise TypeError("Expecting the from_type to be an instance of 'type'")
@@ -70,7 +70,7 @@ class TypeConverter(object):
     @to_type.setter
     def to_type(self, to_type):
         if to_type is not None:
-            if isinstance(to_type, collections.Iterable):
+            if isinstance(to_type, collections.abc.Iterable):
                 for t in to_type:
                     if not isinstance(t, type):
                         raise TypeError("Expecting the to_type to be an instance of 'type'")

--- a/pyrobolearn/utils/data_structures/orderedset.py
+++ b/pyrobolearn/utils/data_structures/orderedset.py
@@ -3,7 +3,7 @@
 """Define the OrderedSet data structure class.
 """
 
-import collections
+import collections.abc
 
 __author__ = "Brian Delhaisse"
 __copyright__ = "Copyright 2018, PyRoboLearn"
@@ -15,7 +15,7 @@ __email__ = "briandelhaisse@gmail.com"
 __status__ = "Development"
 
 
-class OrderedSet(collections.MutableSet):
+class OrderedSet(collections.abc.MutableSet):
     r"""Ordered Set
 
     This is my own implementation of an ordered set, and was inspired a bit from [1] and [2].
@@ -69,7 +69,7 @@ class OrderedSet(collections.MutableSet):
         self._set = set()
         self._list = []
 
-        if isinstance(iterator, collections.Iterable):
+        if isinstance(iterator, collections.abc.Iterable):
             for item in iterator:
                 self.add(item)
 
@@ -413,7 +413,7 @@ class OrderedSet(collections.MutableSet):
 ################################################################################################
 
 
-class OrderedSet2(collections.MutableSet):
+class OrderedSet2(collections.abc.MutableSet):
     r"""Ordered Set
 
     This is my own implementation of an ordered set, and was inspired a bit from [1] and [2].
@@ -472,7 +472,7 @@ class OrderedSet2(collections.MutableSet):
         self._start, self._end = self.NonePtr, self.NonePtr
         self._map = {}
 
-        if isinstance(iterator, collections.Iterable):
+        if isinstance(iterator, collections.abc.Iterable):
             for item in iterator:
                 self.add(item)
 

--- a/pyrobolearn/utils/parsers/robots/data_structures.py
+++ b/pyrobolearn/utils/parsers/robots/data_structures.py
@@ -7,7 +7,7 @@ import copy
 from enum import Enum
 import numpy as np
 import trimesh
-from collections import OrderedDict, Iterable
+from collections.abc import OrderedDict, Iterable
 
 from pyrobolearn.utils.transformation import get_rpy_from_quaternion, get_quaternion_from_rpy, get_matrix_from_rpy, \
     get_rpy_from_matrix, get_matrix_from_axis_angle, get_inverse_homogeneous

--- a/pyrobolearn/utils/transformation.py
+++ b/pyrobolearn/utils/transformation.py
@@ -15,7 +15,7 @@ from scipy.linalg import block_diag
 import quaternion
 # from pyquaternion import Quaternion  # TODO: check API at http://kieranwynn.github.io/pyquaternion
 import sympy
-from collections import Iterable
+from collections.abc import Iterable
 
 from pyrobolearn.utils.converter import QuaternionNumpyConverter
 

--- a/pyrobolearn/worlds/world.py
+++ b/pyrobolearn/worlds/world.py
@@ -9,7 +9,7 @@ Dependencies:
 import os
 import copy
 import inspect
-import collections
+import collections.abc
 import time
 import numpy as np
 import cv2
@@ -313,7 +313,7 @@ class World(object):
     #     Args:
     #         bridges (list, Bridge): list of bridges
     #     """
-    #     if isinstance(bridges, collections.Iterable):
+    #     if isinstance(bridges, collections.abc.Iterable):
     #         for bridge in bridges:
     #             # if not isinstance(bridge, Bridge):
     #             #    raise TypeError("Expecting a list of bridges (must be an instance of Bridge)")
@@ -2029,7 +2029,7 @@ class World(object):
         if isinstance(low, (float, int)) and isinstance(high, (float, int)):
             positions = np.random.uniform(low=low, high=high, size=(size,))
         else:
-            if isinstance(low, collections.Iterable):
+            if isinstance(low, collections.abc.Iterable):
                 positions = np.random.uniform(low=low, high=high, size=(size, len(low)))
             else:
                 positions = np.random.uniform(low=low, high=high, size=(size, len(high)))


### PR DESCRIPTION
At many locations in the code, arguments that are parsed to methods are checked for being an instance of `Iterable`. At the current state, this raises the following warning: `DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working` (tested with Python 3.7). To get rid of the warning as well as to prevent breaking when moving to Python 3.9, I replaced all occurences of `collections` with `collections.abc`. Note that I only did a string replacement in vim for all *.py files and tested a few of the provided worlds if they still run. Having some unit or integration tests would help tremendously changes like this one :) 